### PR TITLE
fix Makefile.in in HLMTools

### DIFF
--- a/HLMTools/Makefile.in
+++ b/HLMTools/Makefile.in
@@ -74,6 +74,6 @@ install: mkinstalldir $(PROGS)
 	for program in $(PROGS) ; do $(INSTALL) -m 755 $${program}@BINARY_EXTENSION@ $(bindir) ; done
 
 mkinstalldir:
-        if [ ! -d $(bindir) -a X_@TRADHTK@ = X_yes ] ; then mkdir -p $(bindir) ; fi
+	if [ ! -d $(bindir) -a X_@TRADHTK@ = X_yes ] ; then mkdir -p $(bindir) ; fi
 
 .PHONY: all strip clean cleanup distclean install mkinstalldir


### PR DESCRIPTION
I just replaced the 8 spaces by a tab to avoid a missing separator error on the line 77.
